### PR TITLE
fix: fixing crash when remove KVO.

### DIFF
--- a/MRLogicInjection/Classes/MRCheckSuper.h
+++ b/MRLogicInjection/Classes/MRCheckSuper.h
@@ -31,7 +31,7 @@
 #define MRPrepareSendSuper(returnType, ...) \
 struct objc_super superInfo = { \
 self, \
-MRGetInjectionSuperClass([self class],__IMP_CLASS__) \
+MRGetInjectionSuperClass(object_getClass(self),__IMP_CLASS__) \
 }; \
 returnType (*method)(struct objc_super*, SEL, ##__VA_ARGS__ ) = (void*)&objc_msgSendSuper
 
@@ -96,4 +96,4 @@ Class MRGetInjectionSuperClass(Class currentClass, Class logicClass);
 /**
  检测当前函数的父类是否实现了当前的函数，如果实现了则返回YES，如果没有实现则返回NO
  */
-#define __MRSuperImplatationCurrentCMD__(selector) MRCheckSuperResponseToSelector([self class], __IMP_CLASS__, selector)
+#define __MRSuperImplatationCurrentCMD__(selector) MRCheckSuperResponseToSelector(object_getClass(self), __IMP_CLASS__, selector)

--- a/MRLogicInjection/Classes/MRExtendClass.m
+++ b/MRLogicInjection/Classes/MRExtendClass.m
@@ -8,7 +8,58 @@
 
 #import "MRExtendClass.h"
 #import <objc/runtime.h>
+#import <pthread.h>
 #import "NSObject+MRInjectionLogicKey.h"
+
+@interface NSObject (MRInjectionSwizzled)
+- (void)MRInjection_KVO_original_removeObserver:(NSObject *)observer forKeyPath:(NSString *)keyPath;
+- (void)MRInjection_KVO_original_removeObserver:(NSObject *)observer forKeyPath:(NSString *)keyPath context:(void *)context;
+@end
+
+static pthread_mutex_t gMutex;
+
+#if USE_BLOCKS_BASED_LOCKING
+#define BLOCK_QUALIFIER __block
+static void WhileLocked(void (^block)(void))
+{
+    pthread_mutex_lock(&gMutex);
+    block();
+    pthread_mutex_unlock(&gMutex);
+}
+#define WhileLocked(block) WhileLocked(^block)
+#else
+#define BLOCK_QUALIFIER
+#define WhileLocked(block) do { \
+        pthread_mutex_lock(&gMutex); \
+        block \
+        pthread_mutex_unlock(&gMutex); \
+    } while(0)
+#endif
+
+static void KVOSubclassRemoveObserverForKeyPath(id self, SEL _cmd, id observer, NSString *keyPath)
+{
+    WhileLocked({
+        IMP originalIMP = class_getMethodImplementation(object_getClass(self), @selector(MRInjection_KVO_original_removeObserver:forKeyPath:));
+        ((void (*)(id, SEL, id, NSString *))originalIMP)(self, _cmd, observer, keyPath);
+    });
+}
+
+static void KVOSubclassRemoveObserverForKeyPathContext(id self, SEL _cmd, id observer, NSString *keyPath, void *context)
+{
+    WhileLocked({
+        IMP originalIMP = class_getMethodImplementation(object_getClass(self), @selector(MRInjection_KVO_original_removeObserver:forKeyPath:context:));
+        ((void (*)(id, SEL, id, NSString *, void *))originalIMP)(self, _cmd, observer, keyPath, context);
+    });
+}
+
+static void MRExtendBaseClassWithLogicClass(Class baseClass, Class logicClass) {
+    unsigned int methodCount = 0;
+    Method* logicMethodList= class_copyMethodList(logicClass, &methodCount);
+    for (int i = 0; i < methodCount; i++) {
+        Method m = logicMethodList[i];
+        class_addMethod(baseClass, method_getName(m), method_getImplementation(m), method_copyReturnType(m));
+    }
+}
 
 NSString* const KMRExtendClassKey = @"__MR_EXTEND_";
 
@@ -31,12 +82,7 @@ Class MRExtendLogicCLass(Class baseClass, Class logicClass, NSString* key) {
     }
     [(id)cla setMr_injection_logic_key:key];
     [(id)cla setMr_injection_logic_class:logicClass];
-    unsigned int methodCount = 0;
-    Method* logicMethodList= class_copyMethodList(logicClass, &methodCount);
-    for (int i = 0; i < methodCount; i++) {
-        Method m = logicMethodList[i];
-        class_addMethod(cla, method_getName(m), method_getImplementation(m), method_copyReturnType(m));
-    }
+    MRExtendBaseClassWithLogicClass(cla, logicClass);
     return cla;
 }
 
@@ -49,6 +95,45 @@ Class MRExtendClass(Class baseClass, NSArray* logicClasses, NSString* key) {
     return aimCla;
 }
 
+static BOOL IsKVOSubclass(id obj) {
+    return [obj class] == class_getSuperclass(object_getClass(obj));
+}
+
+static void PatchKVOSubclass(Class class, NSArray* logicClasses) {
+    Method removeObserverForKeyPath = class_getInstanceMethod(class, @selector(removeObserver:forKeyPath:));
+    
+    for (Class cla in logicClasses) {
+        MRExtendBaseClassWithLogicClass(class, cla);
+    }
+    
+    class_addMethod(class,
+                    @selector(MRInjection_KVO_original_removeObserver:forKeyPath:),
+                    method_getImplementation(removeObserverForKeyPath),
+                    method_getTypeEncoding(removeObserverForKeyPath));
+    
+    class_replaceMethod(class,
+                        @selector(removeObserver:forKeyPath:),
+                        (IMP)KVOSubclassRemoveObserverForKeyPath,
+                        method_getTypeEncoding(removeObserverForKeyPath));
+    
+    
+    
+    // The context variant is only available on 10.7/iOS5+, so only perform that override if the method actually exists.
+    Method removeObserverForKeyPathContext = class_getInstanceMethod(class, @selector(removeObserver:forKeyPath:context:));
+    if(removeObserverForKeyPathContext)
+    {
+        class_addMethod(class,
+                        @selector(MRInjection_KVO_original_removeObserver:forKeyPath:context:),
+                        method_getImplementation(removeObserverForKeyPathContext),
+                        method_getTypeEncoding(removeObserverForKeyPathContext));
+        class_replaceMethod(class,
+                            @selector(removeObserver:forKeyPath:context:),
+                            (IMP)KVOSubclassRemoveObserverForKeyPathContext,
+                            method_getTypeEncoding(removeObserverForKeyPathContext));
+        
+    }
+}
+
 id  MRExtendInstanceLogicWithKey(id object,NSString* logicKey,  NSArray* logicClasses) {
     if (!object) {
         return nil;
@@ -56,7 +141,7 @@ id  MRExtendInstanceLogicWithKey(id object,NSString* logicKey,  NSArray* logicCl
     if (logicKey.length == 0) {
         return nil;
     }
-    Class originClass = [object class];
+    Class originClass = object_getClass(object);
     while ([(id)originClass mr_injection_logic_key]) {
         NSString* key = [(id)originClass mr_injection_logic_key];
         if ([key isEqualToString:logicKey]) {
@@ -65,8 +150,18 @@ id  MRExtendInstanceLogicWithKey(id object,NSString* logicKey,  NSArray* logicCl
         originClass = class_getSuperclass(originClass);
     }
     
-    Class cla = MRExtendClass([object class], logicClasses, logicKey);
-    object_setClass(object, cla);
+    Class cla;
+    if (IsKVOSubclass(object)) {
+        PatchKVOSubclass(originClass, logicClasses);
+        cla = originClass;
+    }
+    else {
+        cla = MRExtendClass(object_getClass(object), logicClasses, logicKey);
+    }
+    
+    if (class_getSuperclass(cla) == originClass) {
+        object_setClass(object, cla);
+    }
     
     return object;
 }


### PR DESCRIPTION
产生原因：isa-swizzle 与 KVO 中的 isa-swizzle 冲突；
复现步骤：先添加 KVO 监听后再进行 isa-swizzle 后，在调用移除 KVO 时 crash，[Demo](https://github.com/Xummer/HookTableViewDelegate)；
解决方案：参考 [MAZeroingWeakRef](https://github.com/mikeash/MAZeroingWeakRef) 的实现，修改后兼容 KVO ；